### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,5 +39,5 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.result }}
         run: |
-          helm package . --version $VERSION --app-version $VERSION --dependency-update
+          helm package . --version $VERSION --app-version v$VERSION --dependency-update
           helm push pocket-id-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
This pull request makes a minor update to the Helm packaging step in the release workflow to ensure consistency in app versioning.

* The `helm package` command now prefixes the app version with `v`, changing `--app-version $VERSION` to `--app-version v$VERSION` in `.github/workflows/release.yml`.


Without that


```
Events:
  Type     Reason                  Age                     From                     Message
  ----     ------                  ----                    ----                     -------
  Normal   Scheduled               9m29s                   default-scheduler        Successfully assigned pocket-id/pocket-id-helm-0 to infrastructure-md-0-chmmx-jpt2c-5dmsn
  Normal   SuccessfulAttachVolume  9m23s                   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-c433342c-e934-4f8a-a822-8f05f61d9871"
  Normal   Pulling                 6m19s (x5 over 9m22s)   kubelet                  Pulling image "ghcr.io/pocket-id/pocket-id:1.8.0"
  Warning  Failed                  6m17s (x5 over 9m20s)   kubelet                  Failed to pull image "ghcr.io/pocket-id/pocket-id:1.8.0": [failed to pull and unpack image "ghcr.io/poc
ket-id/pocket-id:1.8.0": failed to resolve reference "ghcr.io/pocket-id/pocket-id:1.8.0": failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://g
hcr.io/token?scope=repository%3Apocket-id%2Fpocket-id%3Apull&service=ghcr.io: 403 Forbidden, failed to pull and unpack image "ghcr.io/pocket-id/pocket-id:1.8.0": failed to resolve referen
ce "ghcr.io/pocket-id/pocket-id:1.8.0": pull access denied, repository does not exist or may require authorization: authorization failed: no basic auth credentials]
  Warning  Failed                  6m17s (x5 over 9m20s)   kubelet                  Error: ErrImagePull
  Warning  Failed                  4m12s (x20 over 9m19s)  kubelet                  Error: ImagePullBackOff
  Normal   BackOff                 3m57s (x21 over 9m19s)  kubelet                  Back-off pulling image "ghcr.io/pocket-id/pocket-id:1.8.0"
```