### PR TITLE
only mount pv if persistence enabled, mount at correct location

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -56,9 +56,11 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if and .Values.persistence.enabled (not .Values.enterprise.enabled) }}
           volumeMounts:
             - name: {{ include "pocket-id.fullname" . }}-data
-              mountPath: /app/backend/data
+              mountPath: /app/data
+          {{- end }}
             {{- with .Values.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -132,6 +132,9 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
 
+enterprise:
+  enabled: false
+
 # -- Additional volumes on the pod definition.
 volumes: []
 # - name: foo


### PR DESCRIPTION
This PR:
- Edits the PV such that it only mounts if persistence is enabled
- Mounts the PV at the actual location pocket id stores data
- Defaults enterprise.enabled to false